### PR TITLE
Fix paste into Safari

### DIFF
--- a/lib/copyPaste/copyPaste.js
+++ b/lib/copyPaste/copyPaste.js
@@ -67,7 +67,8 @@ CopyPasteClass.prototype.init = function () {
         //Safari adds an additional newline to copied text
         if(navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1) {
           temp = clipboardContents.split('\n');
-          temp.pop();
+          if(temp.slice(-1)[0] === '')
+            temp.pop();
           clipboardContents = temp.join('\n');
         }
 


### PR DESCRIPTION
When pasting text from an app that does not include a line feed to end the clipboard data, the last line that may contain text will be discarded by handsontable.
The following clipboard data will paste 1, 2 and 3 within Handsontable
1\n2\n\3\n
However, the following clipboard data will only paste 1 and 2 (discarding the last column) :
1\n2\n\3